### PR TITLE
Improve HF integration

### DIFF
--- a/look2hear/models/base_model.py
+++ b/look2hear/models/base_model.py
@@ -7,6 +7,8 @@
 import torch
 import torch.nn as nn
 
+from huggingface_hub import PyTorchModelHubMixin
+
 
 def _unsqueeze_to_3d(x):
     """Normalize shape of `x` to [batch, n_chan, time]."""
@@ -32,7 +34,7 @@ def pad_to_appropriate_length(x, lcm):
     return x
 
 
-class BaseModel(nn.Module):
+class BaseModel(nn.Module, PyTorchModelHubMixin, repo_url="https://github.com/JusperLee/Apollo", pipeline_tag="audio-to-audio"):
     def __init__(self, sample_rate, in_chan=1):
         super().__init__()
         self._sample_rate = sample_rate


### PR DESCRIPTION
Hi @JusperLee, 

Thanks for this nice work! Niels here from HF.

I noticed you already use the 🤗 hub for loading the model, which is great! 

This PR aims to improve the integration by:

* adding `from_pretrained` and `push_to_hub` capabilities to the model
* making sure download stats work for your model (similar to models in the Transformers library)

It leverages the [PyTorchModelHubMixin](https://huggingface.co/docs/huggingface_hub/package_reference/mixins#huggingface_hub.PyTorchModelHubMixin) class which allows to inherits these methods.

Usage is as follows:

```python
from base_model import BaseModel

# define model
model = BaseModel(...)

# equip with weights
model.load_state_dict(...)

# push to hub
model.push_to_hub("JusperLee/Apollo")

# reload
model = BaseModel.from_pretrained("JusperLee/Apollo")
```

This means people don't need to manually download a checkpoint first in their local environment, it just loads automatically from the hub.

Would you be interested in this integration?

Kind regards,

Niels

## Note

Please don't merge this PR before pushing the model to the hub from this branch :)