### PR TITLE
Fix loading model on PyTorch>=2.6

### DIFF
--- a/look2hear/models/base_model.py
+++ b/look2hear/models/base_model.py
@@ -62,7 +62,7 @@ class BaseModel(nn.Module, PyTorchModelHubMixin, repo_url="https://github.com/Ju
         from . import get
 
         conf = torch.load(
-            pretrained_model_conf_or_path, map_location="cpu"
+            pretrained_model_conf_or_path, map_location="cpu", weights_only=False
         )  # Attempt to find the model and instantiate it.
 
         model_class = get(conf["model_name"])


### PR DESCRIPTION
Since PyTorch 2.6, weights_only defaults to True for security purposes. This breaks Apollo, let's fix it.

I'm not experienced in PyTorch. If you see a better way of doing this (e.g. recreating the model structure and loading only weights), propose it instead.